### PR TITLE
Handle exceptions in thread workers

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -56,9 +56,14 @@ class _QThreadWorker(QtCore.QThread):
 			)
 			if future.set_running_or_notify_cancel():
 				self._logger.debug('Invoking callback')
-				r = callback(*args, **kwargs)
-				self._logger.debug('Setting Future result: {}'.format(r))
-				future.set_result(r)
+				try:
+					r = callback(*args, **kwargs)
+				except Exception as err:
+					self._logger.debug('Setting Future exception: {}'.format(err))
+					future.set_exception(err)
+				else:
+					self._logger.debug('Setting Future result: {}'.format(r))
+					future.set_result(r)
 			else:
 				self._logger.debug('Future was cancelled')
 

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -73,14 +73,21 @@ def test_can_run_tasks_in_executor(loop, executor):
 		nonlocal was_invoked
 		was_invoked = True
 
-	@asyncio.coroutine
-	def blocking_task():
-		yield from loop.run_in_executor(None, blocking_func)
-
 	was_invoked = False
-	loop.run_until_complete(blocking_task())
+	loop.run_until_complete(loop.run_in_executor(None, blocking_func))
 
 	assert was_invoked
+
+
+def test_can_handle_exception_in_default_executor(loop):
+	"""Verify that exceptions from tasks run in default (threaded) executor are handled."""
+	def blocking_func():
+		raise Exception('Testing')
+
+	with pytest.raises(Exception) as excinfo:
+		loop.run_until_complete(loop.run_in_executor(None, blocking_func))
+
+	assert str(excinfo.value) == 'Testing'
 
 
 def test_can_execute_subprocess(loop):


### PR DESCRIPTION
I discovered that exceptions occurring in background threads (as scheduled through the QThreadExecutor) weren't caught and passed on as they should. This patch rectifies that, and there's a test to prove it :)
