### PR TITLE
Fix removal of r/w-notifiers if another notifier is still bound

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -363,7 +363,8 @@ class QEventLoop(_baseclass):
 		notifier.setEnabled(True)
 		self._logger.debug('Adding reader callback for file descriptor {}'.format(fd))
 		notifier.activated.connect(
-			lambda: self.__on_notifier_ready(notifier, fd, callback, args)
+			lambda: self.__on_notifier_ready(self._read_notifiers,
+							 notifier, fd, callback, args)
 		)
 		self._read_notifiers[fd] = notifier
 
@@ -385,7 +386,8 @@ class QEventLoop(_baseclass):
 		notifier.setEnabled(True)
 		self._logger.debug('Adding writer callback for file descriptor {}'.format(fd))
 		notifier.activated.connect(
-			lambda: self.__on_notifier_ready(notifier, fd, callback, args)
+			lambda: self.__on_notifier_ready(self._write_notifiers,
+							 notifier, fd, callback, args)
 		)
 		self._write_notifiers[fd] = notifier
 
@@ -401,8 +403,8 @@ class QEventLoop(_baseclass):
 		else:
 			notifier.setEnabled(False)
 
-	def __on_notifier_ready(self, notifier, fd, callback, args):
-		if fd not in self._read_notifiers and fd not in self._write_notifiers:
+	def __on_notifier_ready(self, notifiers, notifier, fd, callback, args):
+		if fd not in notifiers:
 			self._logger.warning(
 				'Socket notifier for fd {} is ready, even though it should be disabled, not calling {} and disabling'
 				.format(fd, callback)
@@ -418,7 +420,8 @@ class QEventLoop(_baseclass):
 		try:
 			callback(*args)
 		finally:
-			notifier.setEnabled(True)
+			if fd in notifiers:
+				notifier.setEnabled(True)
 
 	# Methods for interacting with threads.
 


### PR DESCRIPTION
I think this is a regression caused by c412687. That commit adds a wrapper for the callback provided by the user to add_reader/add_writer. The workaround supplied by 43256c0 is not sufficient. The wrapper looks like this on current HEAD:

``` python
    def __on_notifier_ready(self, notifier, fd, callback, args):
        if fd not in self._read_notifiers and fd not in self._write_notifiers:
            self._logger.warning(
                'Socket notifier for fd {} is ready, even though it should be disabled, not calling {} and disabling'
                .format(fd, callback)
            )
            notifier.setEnabled(False)
            return

        # It can be necessary to disable QSocketNotifier when e.g. checking
        # ZeroMQ sockets for events
        assert notifier.isEnabled()
        self._logger.debug('Socket notifier for fd {} is ready'.format(fd))
        notifier.setEnabled(False)
        try:
            callback(*args)
        finally:
            notifier.setEnabled(True)
```

Assume that we have a reader for a `fd` and get notified that data is available to be read on the socket. Now we find out (this happens with SSL, and is handled like this e.g. in the asyncio SSL implementation) that we have to write before we can actually read, so we remove the reader from `fd` and add a writer for `fd`. 

The notifier for the reader gets re-enabled in the finally clause. It may re-trigger immediately, depending on what SSL did under the hoods. The test in line 405 (line 2 in the above paste) will pass, as `fd` is in `_write_notifiers`, leading to a possibly infinite loop of notifications.

I have provided a patch which is supposed to fix this. Take this as an idea, this is more or less a quick fix, it might be possible to do this better.
