### PR TITLE
Improve PEP conformance of add/remove_reader/writer

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -390,8 +390,10 @@ class QEventLoop(_baseclass):
 			self._logger.warning(
 				'Attempt to remove non-existent reader callback for file descriptor {}'.format(fd)
 			)
+			return False
 		else:
 			notifier.setEnabled(False)
+			return True
 
 	def add_writer(self, fd, callback, *args):
 		"""Register a callback for when a file descriptor is ready for writing."""
@@ -426,8 +428,10 @@ class QEventLoop(_baseclass):
 			self._logger.warning(
 				'Attempt to remove non-existent writer callback for file descriptor {}'.format(fd)
 			)
+			return False
 		else:
 			notifier.setEnabled(False)
+			return True
 
 	def __on_notifier_ready(self, notifiers, notifier, fd, callback, args):
 		if fd not in notifiers:

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -359,6 +359,19 @@ class QEventLoop(_baseclass):
 
 	def add_reader(self, fd, callback, *args):
 		"""Register a callback for when a file descriptor is ready for reading."""
+		try:
+			existing = self._read_notifiers[fd]
+		except KeyError:
+			pass
+		else:
+			# this is neccessary to avoid race condition-like issues
+			existing.setEnabled(False)
+			existing.activated.disconnect()
+			# will get overwritten by the assignment below anyways
+			self._logger.warning(
+				'There is already a reader attached for fd {}'.format(fd)
+			)
+
 		notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read)
 		notifier.setEnabled(True)
 		self._logger.debug('Adding reader callback for file descriptor {}'.format(fd))
@@ -382,6 +395,19 @@ class QEventLoop(_baseclass):
 
 	def add_writer(self, fd, callback, *args):
 		"""Register a callback for when a file descriptor is ready for writing."""
+		try:
+			existing = self._write_notifiers[fd]
+		except KeyError:
+			pass
+		else:
+			# this is neccessary to avoid race condition-like issues
+			existing.setEnabled(False)
+			existing.activated.disconnect()
+			# will get overwritten by the assignment below anyways
+			self._logger.warning(
+				'There is already a writer attached for fd {}'.format(fd)
+			)
+
 		notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Write)
 		notifier.setEnabled(True)
 		self._logger.debug('Adding writer callback for file descriptor {}'.format(fd))

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -368,9 +368,6 @@ class QEventLoop(_baseclass):
 			existing.setEnabled(False)
 			existing.activated.disconnect()
 			# will get overwritten by the assignment below anyways
-			self._logger.warning(
-				'There is already a reader attached for fd {}'.format(fd)
-			)
 
 		notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read)
 		notifier.setEnabled(True)
@@ -387,9 +384,6 @@ class QEventLoop(_baseclass):
 		try:
 			notifier = self._read_notifiers.pop(fd)
 		except KeyError:
-			self._logger.warning(
-				'Attempt to remove non-existent reader callback for file descriptor {}'.format(fd)
-			)
 			return False
 		else:
 			notifier.setEnabled(False)
@@ -406,9 +400,6 @@ class QEventLoop(_baseclass):
 			existing.setEnabled(False)
 			existing.activated.disconnect()
 			# will get overwritten by the assignment below anyways
-			self._logger.warning(
-				'There is already a writer attached for fd {}'.format(fd)
-			)
 
 		notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Write)
 		notifier.setEnabled(True)
@@ -425,9 +416,6 @@ class QEventLoop(_baseclass):
 		try:
 			notifier = self._write_notifiers.pop(fd)
 		except KeyError:
-			self._logger.warning(
-				'Attempt to remove non-existent writer callback for file descriptor {}'.format(fd)
-			)
 			return False
 		else:
 			notifier.setEnabled(False)

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -523,7 +523,6 @@ def test_regression_bug13(loop, sock_pair):
 	assert result3 == b'3'
 
 
-
 def test_add_reader_replace(loop, sock_pair):
 	c_sock, s_sock = sock_pair
 	callback_invoked = asyncio.Future()
@@ -566,8 +565,9 @@ def test_add_reader_replace(loop, sock_pair):
 	client_done = asyncio.async(client_coro())
 	server_done = asyncio.async(server_coro())
 
-	both_done = asyncio.wait([server_done, client_done],
-				 return_when=asyncio.FIRST_EXCEPTION)
+	both_done = asyncio.wait(
+		[server_done, client_done],
+		return_when=asyncio.FIRST_EXCEPTION)
 	loop.run_until_complete(asyncio.wait_for(both_done, timeout=0.1))
 	assert not called1
 	assert called2
@@ -606,8 +606,9 @@ def test_add_writer_replace(loop, sock_pair):
 
 	client_done = asyncio.async(client_coro())
 
-	both_done = asyncio.wait([client_done],
-				 return_when=asyncio.FIRST_EXCEPTION)
+	both_done = asyncio.wait(
+		[client_done],
+		return_when=asyncio.FIRST_EXCEPTION)
 	loop.run_until_complete(asyncio.wait_for(both_done, timeout=0.1))
 	assert not called1
 	assert called2

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -521,3 +521,93 @@ def test_regression_bug13(loop, sock_pair):
 	loop.run_until_complete(asyncio.wait_for(both_done, timeout=1.0))
 	assert result1 == b'1'
 	assert result3 == b'3'
+
+
+
+def test_add_reader_replace(loop, sock_pair):
+	c_sock, s_sock = sock_pair
+	callback_invoked = asyncio.Future()
+
+	called1 = False
+	called2 = False
+
+	def any_callback():
+		if not callback_invoked.done():
+			callback_invoked.set_result(True)
+		loop.remove_reader(c_sock.fileno())
+
+	def callback1():
+		# the "bad" callback: if this gets invoked, something went wrong
+		nonlocal called1
+		called1 = True
+		any_callback()
+
+	def callback2():
+		# the "good" callback: this is the one which should get called
+		nonlocal called2
+		called2 = True
+		any_callback()
+
+	@asyncio.coroutine
+	def server_coro():
+		s_reader, s_writer = yield from asyncio.open_connection(
+			sock=s_sock)
+		s_writer.write(b"foo")
+		yield from s_writer.drain()
+
+	@asyncio.coroutine
+	def client_coro():
+		loop.add_reader(c_sock.fileno(), callback1)
+		loop.add_reader(c_sock.fileno(), callback2)
+		yield from callback_invoked
+		loop.remove_reader(c_sock.fileno())
+		assert (yield from loop.sock_recv(c_sock, 3)) == b"foo"
+
+	client_done = asyncio.async(client_coro())
+	server_done = asyncio.async(server_coro())
+
+	both_done = asyncio.wait([server_done, client_done],
+				 return_when=asyncio.FIRST_EXCEPTION)
+	loop.run_until_complete(asyncio.wait_for(both_done, timeout=0.1))
+	assert not called1
+	assert called2
+
+
+def test_add_writer_replace(loop, sock_pair):
+	c_sock, s_sock = sock_pair
+	callback_invoked = asyncio.Future()
+
+	called1 = False
+	called2 = False
+
+	def any_callback():
+		if not callback_invoked.done():
+			callback_invoked.set_result(True)
+		loop.remove_writer(c_sock.fileno())
+
+	def callback1():
+		# the "bad" callback: if this gets invoked, something went wrong
+		nonlocal called1
+		called1 = True
+		any_callback()
+
+	def callback2():
+		# the "good" callback: this is the one which should get called
+		nonlocal called2
+		called2 = True
+		any_callback()
+
+	@asyncio.coroutine
+	def client_coro():
+		loop.add_writer(c_sock.fileno(), callback1)
+		loop.add_writer(c_sock.fileno(), callback2)
+		yield from callback_invoked
+		loop.remove_writer(c_sock.fileno())
+
+	client_done = asyncio.async(client_coro())
+
+	both_done = asyncio.wait([client_done],
+				 return_when=asyncio.FIRST_EXCEPTION)
+	loop.run_until_complete(asyncio.wait_for(both_done, timeout=0.1))
+	assert not called1
+	assert called2

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -612,3 +612,35 @@ def test_add_writer_replace(loop, sock_pair):
 	loop.run_until_complete(asyncio.wait_for(both_done, timeout=0.1))
 	assert not called1
 	assert called2
+
+
+def test_remove_reader_idempotence(loop, sock_pair):
+	fd = sock_pair[0].fileno()
+
+	def cb():
+		pass
+
+	removed0 = loop.remove_reader(fd)
+	loop.add_reader(fd, cb)
+	removed1 = loop.remove_reader(fd)
+	removed2 = loop.remove_reader(fd)
+
+	assert not removed0
+	assert removed1
+	assert not removed2
+
+
+def test_remove_writer_idempotence(loop, sock_pair):
+	fd = sock_pair[0].fileno()
+
+	def cb():
+		pass
+
+	removed0 = loop.remove_writer(fd)
+	loop.add_writer(fd, cb)
+	removed1 = loop.remove_writer(fd)
+	removed2 = loop.remove_writer(fd)
+
+	assert not removed0
+	assert removed1
+	assert not removed2


### PR DESCRIPTION
According to [PEP 3156, Section "I/O Callbacks"][0], calling each of remove_reader/writer and add_reader/writer multiple times in sequence on the same fd without adding/removing a reader/writer inbetween is legal. Logging a warning is thus not neccessary and only produces noise when debugging applications.

In addition, the correct return values for remove_{reader,writer} have been implemented.

Note: this pull request depends on and includes #19 (I probably should have handled this differently).

   [0]: https://www.python.org/dev/peps/pep-3156/#i-o-callbacks
