### PR TITLE
Instantiate QApplication once for all (doc)tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ _app = None
 
 @fixture
 def app():
-	from PyQt5.QtWidgets import QApplication
+	from quamash import QApplication
 	global _app
 	if _app is None:
 		_app = QApplication([])

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ else:
 
 _app = None
 
+
 @fixture
 def app():
 	from quamash import QApplication

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import sys
 import os.path
 import logging
+from pytest import fixture
 sys.path.insert(0, os.path.dirname(__file__))
 logging.basicConfig(
 	level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
@@ -9,3 +10,13 @@ if os.name == 'nt':
 	collect_ignore = ['quamash/_unix.py']
 else:
 	collect_ignore = ['quamash/_windows.py']
+
+_app = None
+
+@fixture
+def app():
+	from PyQt5.QtWidgets import QApplication
+	global _app
+	if _app is None:
+		_app = QApplication([])
+	return _app

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -177,10 +177,9 @@ def _easycallback(fn):
 	>>> import asyncio
 	>>>
 	>>> import quamash
-	>>> from quamash import QEventLoop, QtCore, QtGui, QApplication
 	>>> QThread, QObject = quamash.QtCore.QThread, quamash.QtCore.QObject
 	>>>
-	>>> app = QApplication.instance() or QApplication([])
+	>>> app = getfixture('app')
 	>>>
 	>>> global_thread = QThread.currentThread()
 	>>> class MyObject(QObject):
@@ -231,9 +230,9 @@ class QEventLoop(_baseclass):
 	"""
 	Implementation of asyncio event loop that uses the Qt Event loop.
 
-	>>> import quamash, asyncio
-	>>> from quamash import QtCore, QtGui, QApplication
-	>>> app = QApplication.instance() or QApplication([])
+	>>> import asyncio
+	>>>
+	>>> app = getfixture('app')
 	>>>
 	>>> @asyncio.coroutine
 	... def xplusy(x, y):


### PR DESCRIPTION
Introduce fixture to provide QApplication instance to doctests, that is only created once throughout the whole test session. This is because instantiating QApplication multiple times can lead to crashes (on Linux at least).