### PR TITLE
create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst LICENSE


### PR DESCRIPTION
This causes LICENSE to be included in the sdist.
fixes #35