### PR TITLE
fix _ProactorEventLoop initialization bug

### DIFF
--- a/quamash/_windows.py
+++ b/quamash/_windows.py
@@ -26,8 +26,7 @@ class _ProactorEventLoop(QtCore.QObject, asyncio.ProactorEventLoop):
 	"""Proactor based event loop."""
 
 	def __init__(self):
-		QtCore.QObject.__init__(self)
-		asyncio.ProactorEventLoop.__init__(self, _IocpProactor())
+		super().__init__(proactor=_IocpProactor())
 
 		self.__event_poller = _EventPoller()
 		self.__event_poller.sig_events.connect(self._process_events)


### PR DESCRIPTION
`QtCore.QObject.__init__(self)` and `asyncio.ProactorEventLoop.__init__(self, _IocpProactor())` causes double initialization of asyncio.ProactorEventLoop, according to mro.
Possibly related to #38.