### PR TITLE
Fix fds handling after closing + check if loop is closed

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -381,6 +381,8 @@ class QEventLoop(_baseclass):
 
 	def add_reader(self, fd, callback, *args):
 		"""Register a callback for when a file descriptor is ready for reading."""
+		self._check_closed()
+
 		try:
 			existing = self._read_notifiers[fd]
 		except KeyError:
@@ -417,6 +419,7 @@ class QEventLoop(_baseclass):
 
 	def add_writer(self, fd, callback, *args):
 		"""Register a callback for when a file descriptor is ready for writing."""
+		self._check_closed()
 		try:
 			existing = self._write_notifiers[fd]
 		except KeyError:

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -310,6 +310,11 @@ class QEventLoop(_baseclass):
 
 		The loop cannot be restarted after it has been closed.
 		"""
+		if self.is_running():
+			raise RuntimeError("Cannot close a running event loop")
+		if self.is_closed():
+			return
+
 		self._logger.debug('Closing event loop...')
 		if self.__default_executor is not None:
 			self.__default_executor.shutdown()
@@ -397,6 +402,10 @@ class QEventLoop(_baseclass):
 
 	def remove_reader(self, fd):
 		"""Remove reader callback."""
+
+		if self.is_closed():
+			return
+
 		self._logger.debug('Removing reader callback for file descriptor {}'.format(fd))
 		try:
 			notifier = self._read_notifiers.pop(fd)
@@ -429,6 +438,10 @@ class QEventLoop(_baseclass):
 
 	def remove_writer(self, fd):
 		"""Remove writer callback."""
+
+		if self.is_closed():
+			return
+
 		self._logger.debug('Removing writer callback for file descriptor {}'.format(fd))
 		try:
 			notifier = self._write_notifiers.pop(fd)

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -399,24 +399,37 @@ def test_can_remove_reader(loop, sock_pair):
 
 	assert got_msg is None, 'Should not have received a read notification'
 
-def test_can_remove_reader_after_closing(loop, sock_pair):
+def test_remove_reader_after_closing(loop, sock_pair):
 	"""Verify that we can remove a reader callback from an event loop."""
-	def can_read():
-		data = srv_sock.recv(1)
-		if len(data) != 1:
-			return
-
-		nonlocal got_msg
-		got_msg = data
-
 	client_sock, srv_sock = sock_pair
 
-	got_msg = None
-	loop.add_reader(srv_sock.fileno(), can_read)
+	loop.add_reader(srv_sock.fileno(), lambda: None)
 	loop.close()
 	loop.remove_reader(srv_sock.fileno())
 
-	assert got_msg is None, 'Should not have received a read notification'
+def test_remove_writer_after_closing(loop, sock_pair):
+	"""Verify that we can remove a reader callback from an event loop."""
+	client_sock, srv_sock = sock_pair
+
+	loop.add_writer(client_sock.fileno(), lambda: None)
+	loop.close()
+	loop.remove_writer(client_sock.fileno())
+
+def test_add_reader_after_closing(loop, sock_pair):
+	"""Verify that we can remove a reader callback from an event loop."""
+	client_sock, srv_sock = sock_pair
+
+	loop.close()
+	with pytest.raises(RuntimeError):
+		loop.add_reader(srv_sock.fileno(), lambda:None)
+
+def test_add_writer_after_closing(loop, sock_pair):
+	"""Verify that we can remove a reader callback from an event loop."""
+	client_sock, srv_sock = sock_pair
+
+	loop.close()
+	with pytest.raises(RuntimeError):
+		loop.add_writer(client_sock.fileno(), lambda:None)
 
 def test_can_add_writer(loop, sock_pair):
 	"""Verify that we can add a writer callback to an event loop."""

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -399,6 +399,24 @@ def test_can_remove_reader(loop, sock_pair):
 
 	assert got_msg is None, 'Should not have received a read notification'
 
+def test_can_remove_reader_after_closing(loop, sock_pair):
+	"""Verify that we can remove a reader callback from an event loop."""
+	def can_read():
+		data = srv_sock.recv(1)
+		if len(data) != 1:
+			return
+
+		nonlocal got_msg
+		got_msg = data
+
+	client_sock, srv_sock = sock_pair
+
+	got_msg = None
+	loop.add_reader(srv_sock.fileno(), can_read)
+	loop.close()
+	loop.remove_reader(srv_sock.fileno())
+
+	assert got_msg is None, 'Should not have received a read notification'
 
 def test_can_add_writer(loop, sock_pair):
 	"""Verify that we can add a writer callback to an event loop."""


### PR DESCRIPTION
So, using aiohttp and quamash made me found a difference between asyncio loops behaviour and quamash loops : 

When closing the web application, I had uncritical errors : 

```
Exception ignored in: <generator object ServerHttpProtocol.start at 0x7febb8303410>
Traceback (most recent call last):
  File "/home/inso/.pyenv/versions/sakia-env/lib/python3.5/site-packages/aiohttp/server.py", line 306, in start
  File "/home/inso/.pyenv/versions/3.5.0/lib/python3.5/asyncio/selector_events.py", line 563, in close
  File "/home/inso/.pyenv/versions/sakia-env/lib/python3.5/site-packages/quamash/__init__.py", line 405, in remove_reader
AttributeError: 'NoneType' object has no attribute 'pop'
```

To compare why this didn't happen with a standard asyncio loop, I checked the difference between quamash. And in asyncio event loops, if the loop is closed, the remove writer and reader and returned ( https://github.com/python/asyncio/blob/39c135baf73762830148236da622787052efba19/asyncio/selector_events.py#L247 )
When the loop is closed, the add writer and reader methods raise RuntimeError 
( https://github.com/python/asyncio/blob/39c135baf73762830148236da622787052efba19/asyncio/selector_events.py#L231 )

There is tests in asyncio for these cases : 
https://github.com/python/asyncio/blob/39c135baf73762830148236da622787052efba19/tests/test_events.py#L1594
https://github.com/python/asyncio/blob/39c135baf73762830148236da622787052efba19/tests/test_events.py#L1606

Also, when we close the loop, if it is closed, we should return immediately like asyncio ( https://github.com/python/asyncio/blob/39c135baf73762830148236da622787052efba19/asyncio/base_events.py#L393 )

