### PR TITLE
Remove dependence on module 'QtWidgets'

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -43,8 +43,7 @@ logger.info('Using Qt Implementation: {}'.format(QtModuleName))
 QtCore = __import__(QtModuleName + '.QtCore', fromlist=(QtModuleName,))
 QtGui = __import__(QtModuleName + '.QtGui', fromlist=(QtModuleName,))
 if QtModuleName == 'PyQt5':
-	from PyQt5 import QtWidgets
-	QApplication = QtWidgets.QApplication
+	QApplication = QtCore.QCoreApplication
 else:
 	QApplication = QtGui.QApplication
 


### PR DESCRIPTION
Hi, it seems that QApplication is not necessary and can't be replaced by QCoreApplication, so dependency on module 'QtWidgets' can be removed. :smile: