### PR TITLE
Remove dependence on modules: QtWidgets, QtGui

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -41,13 +41,6 @@ if not QtModule:
 logger.info('Using Qt Implementation: {}'.format(QtModuleName))
 
 QtCore = __import__(QtModuleName + '.QtCore', fromlist=(QtModuleName,))
-QtGui = __import__(QtModuleName + '.QtGui', fromlist=(QtModuleName,))
-if QtModuleName == 'PyQt5':
-	from PyQt5 import QtWidgets
-	QApplication = QtWidgets.QApplication
-else:
-	QApplication = QtGui.QApplication
-
 
 from ._common import with_logger
 
@@ -237,8 +230,8 @@ class _QEventLoop:
 	"""
 
 	def __init__(self, app=None):
-		self.__app = app or QApplication.instance()
-		assert self.__app is not None, 'No QApplication has been instantiated'
+		self.__app = app or QtCore.QCoreApplication.instance()
+		assert self.__app is not None, 'No QCoreApplication has been instantiated'
 		self.__is_running = False
 		self.__debug_enabled = False
 		self.__default_executor = None


### PR DESCRIPTION
The `QCoreApplication` class provides an event loop for basic Qt applications. `QApplication` is not necessary for every application.

`QGuiApplication` and `QApplication` can be used as the following way for some Gui Applications.

```Python
app = QApplication(sys.argv)
loop = QEventLoop(app)
asyncio.set_event_loop(loop)
```