### PR TITLE
Make QThreadExecutor inherit from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -29,7 +29,7 @@ else:
 	QtModule = importlib.import_module(QtModuleName)
 
 if not QtModule:
-	for QtModuleName in ('PyQt5', 'PyQt4', 'PySide'):
+	for QtModuleName in ('PyQt5', 'PyQt4', 'PySide', 'PySide2'):
 		try:
 			QtModule = importlib.import_module(QtModuleName)
 		except ImportError:
@@ -45,6 +45,9 @@ QtCore = importlib.import_module(QtModuleName + '.QtCore', package=QtModuleName)
 QtGui = importlib.import_module(QtModuleName + '.QtGui', package=QtModuleName)
 if QtModuleName == 'PyQt5':
 	from PyQt5 import QtWidgets
+	QApplication = QtWidgets.QApplication
+elif QtModuleName == 'PySide2':
+	from PySide2 import QtWidgets
 	QApplication = QtWidgets.QApplication
 else:
 	QApplication = QtGui.QApplication

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -29,7 +29,7 @@ else:
 	QtModule = importlib.import_module(QtModuleName)
 
 if not QtModule:
-	for QtModuleName in ('PyQt5', 'PyQt4', 'PySide', 'PySide2'):
+	for QtModuleName in ('PyQt5', 'PyQt4', 'PySide'):
 		try:
 			QtModule = importlib.import_module(QtModuleName)
 		except ImportError:
@@ -45,9 +45,6 @@ QtCore = importlib.import_module(QtModuleName + '.QtCore', package=QtModuleName)
 QtGui = importlib.import_module(QtModuleName + '.QtGui', package=QtModuleName)
 if QtModuleName == 'PyQt5':
 	from PyQt5 import QtWidgets
-	QApplication = QtWidgets.QApplication
-elif QtModuleName == 'PySide2':
-	from PySide2 import QtWidgets
 	QApplication = QtWidgets.QApplication
 else:
 	QApplication = QtGui.QApplication

--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -15,7 +15,7 @@ import asyncio
 import time
 import itertools
 from queue import Queue
-from concurrent.futures import Future
+from concurrent.futures import Future, Executor as ExecutorABC
 import logging
 import importlib
 logger = logging.getLogger('quamash')
@@ -102,7 +102,7 @@ class _QThreadWorker(QtCore.QThread):
 
 
 @with_logger
-class QThreadExecutor:
+class QThreadExecutor(ExecutorABC):
 
 	"""
 	ThreadExecutor that produces QThreads.


### PR DESCRIPTION
`QThreadExecutor` now inherits from the `concurrent.futures.Executor`
abstract class. See #102

Excuse the PySide2 commits, didn't see the work that was being put in on the other PR.