### PR TITLE
Fix DeprecationWarning in Python 3.7

### DIFF
--- a/quamash/_unix.py
+++ b/quamash/_unix.py
@@ -6,7 +6,10 @@
 
 import asyncio
 import selectors
-import collections
+try:
+	from collections.abc import Mapping
+except ImportError:
+	from collections import Mapping
 
 from . import QtCore, with_logger
 
@@ -41,7 +44,7 @@ def _fileobj_to_fd(fileobj):
 	return fd
 
 
-class _SelectorMapping(collections.Mapping):
+class _SelectorMapping(Mapping):
 
 	"""Mapping of file objects to selector keys."""
 


### PR DESCRIPTION
...while preserving backward-compatibility with previous versions of Python.

The warning message is:

> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class _SelectorMapping(collections.Mapping):
