### PR TITLE
Explicitly convert float to int for startTimer

### DIFF
--- a/quamash/__init__.py
+++ b/quamash/__init__.py
@@ -180,7 +180,11 @@ class _SimpleTimer(QtCore.QObject):
 		self._stopped = False
 
 	def add_callback(self, handle, delay=0):
-		timerid = self.startTimer(delay * 1000)
+		"""
+		delay should be in seconds(float or int), while
+		startTimer accepts milliseconds(int)
+		"""
+		timerid = self.startTimer(round(delay * 1000))
 		self._logger.debug("Registering timer id {0}".format(timerid))
 		assert timerid not in self.__callbacks
 		self.__callbacks[timerid] = handle


### PR DESCRIPTION
As of Python3.10:
> Builtin and extension functions that take integer arguments no longer
accept Decimals, Fractions and other objects that can be converted to
integers only with a loss (e.g. that have the int() method but do not
have the index() method). (Contributed by Serhiy Storchaka in
bpo-37999.)

`startTimer` accepts only integers (milliseconds) and fails to
implicitly convert floats.

Fixes: https://github.com/harvimt/quamash/issues/128